### PR TITLE
Memoizing sentinel client prevents leaking conns

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -31,11 +31,15 @@ class Redis::Client
       return @sentinels[0]
     end
 
-    def discover_master
-      masters = []
+    def redis_sentinels
+      @redis_sentinels ||= Hash.new do |hash, config|
+        hash[config] = Redis.new(config)
+      end
+    end
 
+    def discover_master
       while true
-        sentinel = Redis.new(@sentinels[0])
+        sentinel = redis_sentinels[@sentinels[0]]
 
         begin
           host, port = sentinel.sentinel("get-master-addr-by-name", @master_name)


### PR DESCRIPTION
Before, a new connection would be established to the sentinel each time
you tried to discover master and then it leaked. If you are doing that a
lot, it results in an error Errno::EMFILE too many open files.

This code lazily caches the sentinel connections as they are needed.
