### PR TITLE
Reconnect Sentinel clients when calling reconnect

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -78,11 +78,15 @@ class Redis::Client
       end
     end
 
-    def reconnect_sentinels
+    def reconnect_with_sentinels
       redis_sentinels.each do |config, sentinel|
         sentinel.client.reconnect
       end
+      reconnect_without_sentinels
     end
+
+    alias reconnect_without_sentinels reconnect
+    alias reconnect reconnect_with_sentinels
 
   private
 

--- a/spec/redis-sentinel/client_spec.rb
+++ b/spec/redis-sentinel/client_spec.rb
@@ -172,16 +172,15 @@ describe Redis::Client do
     end
   end
 
-  context "#reconnect_sentinels" do
+  context "#reconnect" do
     it "calls reconnect on each sentinel client" do
+      subject.stub(:connect)
       subject.discover_master
-      sentinels = subject.send(:redis_sentinels)
-
-      sentinels.each do |config, sentinel|
+      subject.send(:redis_sentinels).each do |config, sentinel|
         sentinel.client.should_receive(:reconnect)
       end
 
-      subject.reconnect_sentinels
+      subject.reconnect
     end
   end
 


### PR DESCRIPTION
Gems that fork processes require you to reconnect redis clients after they fork a process.  Resque and Passenger are 2 of these gems.  This pull patches the `reconnect` method to also call reconnect on each of the sentinel Redis clients.

Without reconnecting the Sentinel Redis clients you'll get `Redis::InheritedError` exceptions.
