### PR TITLE
Avoid that the config passed to the client gets modified

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -5,6 +5,7 @@ class Redis::Client
 
   class_eval do
     def initialize_with_sentinel(options={})
+      options = options.dup # Don't touch my options
       @master_name = fetch_option(options, :master_name)
       @master_password = fetch_option(options, :master_password)
       @sentinels = fetch_option(options, :sentinels)


### PR DESCRIPTION
The configuration passed to the Redis::Client instance gets modified. This is an unexpected behavior that might cause side effects if you don't notice it :)
