### PR TITLE
Randomize sentinel order per-run, so that not all redis-sentinel instances use the exact same sentinel.

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -9,6 +9,7 @@ class Redis::Client
       @master_name = fetch_option(options, :master_name)
       @master_password = fetch_option(options, :master_password)
       @sentinels = fetch_option(options, :sentinels)
+      @sentinels.shuffle! if @sentinels
       @failover_reconnect_timeout = fetch_option(options, :failover_reconnect_timeout)
       @failover_reconnect_wait = fetch_option(options, :failover_reconnect_wait) ||
                                  DEFAULT_FAILOVER_RECONNECT_WAIT_SECONDS


### PR DESCRIPTION
The way that redis-sentinel uses the sentinels array, it is guaranteed that all instances of it will use the same sentinel at all times.  This is less than ideal -- preferably, if there are N sentinels alive then we want our clients to spread out over them to mitigate the impact of the loss of a sentinel.

If we randomize the sentinel array ordering during redis-sentinel initialization, that should have the desired effect.
