### PR TITLE
Add compatibility with the 4-arg version of is-master-down-by-addr

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -67,7 +67,8 @@ class Redis::Client
             raise Redis::ConnectionError.new("No master named: #{@master_name}")
           end
           master_info = sentinel.sentinel("masters").map{ |e| e = Hash[*e.flatten] }
-          if master_info.select{ |e| e['name'] == @master_name }
+          master_info.keep_if{ |e| e['name'] == @master_name }
+          if ! master_info.empty?
             runid = master_info[0]['runid']
           end
           if ! runid


### PR DESCRIPTION
Redis 2.8.0 adopted the upstream (v3?) version of the sentinel protocol.  I can't claim to understand all the changes, but the net impact to redis-sentinel is that is-master-down-by-addr requires two additional args: the current time and the runid.

This is the quickest patch solution I could find to get back up and running after moving from 2.8.0-rc6 to 2.8.0.  I welcome more elegant solutions if there are any.
