### PR TITLE
uniq! function returns nil. it returns nil at jruby

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -62,7 +62,8 @@ class Redis::Client
       current_sentinel.sentinel("sentinels", @master_name).each do |response|
         @sentinels_options << {:host => response[3], :port => response[5]}
       end
-      @sentinels_options.uniq! {|h| h.values_at(:host, :port) }
+      @sentinels_options.uniq!
+      @sentinels_options.each {|h| h.values_at(:host, :port) }
     end
 
     def discover_master


### PR DESCRIPTION
Hi, all

There is a missed implementation at jruby 1.7.10 (also 1.7.9)
the uniq! function for an array doesn't work properly. 

please, check this issue. 
https://github.com/jruby/jruby/issues/1434

so, here is a workaround-way to use the library in a jruby environment.

It works fine.
