### PR TITLE
Rake task to start a console with the gem loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,12 @@ RSpec::Core::RakeTask.new('spec:progress') do |spec|
   spec.pattern = "spec/**/*_spec.rb"
 end
 
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'redis-sentinel'
+  ARGV.clear
+  IRB.start
+end
+
 task :default => :spec


### PR DESCRIPTION
I found that having a rake task to load the gem is pretty useful when developping (cf http://erniemiller.org/2014/02/05/7-lines-every-gems-rakefile-should-have/), so this pull requests adds a task for it. Use with `rake console`.
