### PR TITLE
fixed compatibility issues with Ruby 1.8.7

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -95,7 +95,7 @@ class Redis::Client
           slaves_info = current_sentinel.sentinel("slaves", @master_name)
           @slaves = slaves_info.map do |info|
             info = Hash[*info]
-            ::Redis.new host: info['ip'], port: info['port'], driver: options[:driver]
+            ::Redis.new :host => info['ip'], :port => info['port'], :driver => options[:driver]
           end
 
           break
@@ -170,8 +170,8 @@ class Redis::Client
         else
           uri = URI.parse(opts)
           sentinel_options << {
-            host: uri.host,
-            port: uri.port
+            :host => uri.host,
+            :port => uri.port
           }
         end
       end


### PR DESCRIPTION
This fixes the issue with Ruby 1.8.7 where hash syntax was causing an error:

``` ruby
/var/lib/gems/1.8/gems/redis-sentinel-1.4.3/lib/redis-sentinel/client.rb:143: odd number list for Hash (SyntaxError)
            host: uri.host,
                 ^
```

The old syntax was already in use ([e.g. in here](https://github.com/flyerhzm/redis-sentinel/blob/master/lib/redis-sentinel/client.rb#L76)) so I've changed the other instances to make it 1.8.7 compatible.
