### PR TITLE
Merge slaves discovered options with original

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -100,7 +100,7 @@ class Redis::Client
           slaves_info = current_sentinel.sentinel("slaves", @master_name)
           @slaves = slaves_info.map do |info|
             info = Hash[*info]
-            ::Redis.new :host => info['ip'], :port => info['port'], :driver => info[:driver]
+            ::Redis.new(@options.merge(:host => info['ip'], :port => info['port'], :driver => info[:driver]))
           end
 
           break


### PR DESCRIPTION
This is intended to fix following case:

``` ruby
redis = Redis.new(url: "redis://localhost:6379/2", master_name: "master", sentinels: ["sentinel://localhost:26379", "sentinel://localhost:36379"])
```

As you can see, I also specified connection url which contains database number, 2.
Before this patch:

``` ruby
> redis.all_clients
=> [#<Redis client v3.1.0 for redis://127.0.0.1:6379/2>, #<Redis client v3.1.0 for redis://127.0.0.1:6380/0>]
```

After patch:

``` ruby
> redis.all_clients
=> [#<Redis client v3.1.0 for redis://127.0.0.1:6379/2>, #<Redis client v3.1.0 for redis://127.0.0.1:6380/2>]
```

However, I'm not sure if this is correct way to do things, and how should I properly test it.
What do you think?
