### PR TITLE
Update README to inform users of redis-sentinel's lazy loading behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Sentinels can also be specified using a URI. This URI syntax is required when us
     config.cache_store = :redis_store, { master_name: "master1",
                                          sentinels: ['sentinel://localhost:26379', 'sentinel://localhost:26380'] }
 
-If none of the sentinel servers can be reached, a Redis::CannotConnectError will be thrown.
+After doing the above, you might still see `#<Redis client v3.1.0 for redis://localhost:6379/0>`. 
+This is fine because redis-sentinel will only try to connect when it is actually required. 
+
+However, if none of the sentinel servers can be reached, a Redis::CannotConnectError will be thrown.
 
 There are two additional options:
 


### PR DESCRIPTION
This PR is basically to inform users that it is actually ok to see a #<Redis client v3.1.0 for redis://localhost:6379/0> after initializing a Redis object. This is because redis-sentinel lazy-loads

While trying to setup redis-sentinel for myself, I kept seeing #<Redis client v3.1.0 for redis://localhost:6379/0> while trying to initialize a redis object in Rails Conosle. I only managed to figure out that redis-sentinel lazy loads after digging into the source code with a friend. 
