### PR TITLE
Fix thread and connection leaking

### DIFF
--- a/lib/redis-sentinel/client.rb
+++ b/lib/redis-sentinel/client.rb
@@ -15,7 +15,7 @@ class Redis::Client
       @failover_reconnect_wait = fetch_option(options, :failover_reconnect_wait) ||
                                  DEFAULT_FAILOVER_RECONNECT_WAIT_SECONDS
 
-      Thread.new { watch_sentinel } if sentinel? && !fetch_option(options, :async)
+      @watch_thread = Thread.new { watch_sentinel } if sentinel? && !fetch_option(options, :async)
 
       initialize_without_sentinel(options)
     end
@@ -124,6 +124,7 @@ class Redis::Client
 
     def disconnect_with_sentinels
       current_sentinel.client.disconnect if current_sentinel
+      @watch_thread.kill if @watch_thread
       disconnect_without_sentinels
     end
 


### PR DESCRIPTION
Hey,

Ran into this recently, don't really have any thoughts on what might be a decent way to test for this behavior.

My test was essentially doing this -
```ruby
settings = {
  :master_name => redis_settings["master_name"],
  :sentinels => redis_settings["sentinels"]
}

puts "Starting up on #{$$}"

1000.times do
  r = Redis.new(settings)
  r.info
  r.quit
end

puts "Done"

gets
```

And what happens without this patch is that at the end of the run your'e stuck with 1000 extra connections and threads ( that is, if you don't run out of FDs first ).

Let me know if you have any thoughts on what a test for this would look like or if you think this is good to merge as-is.

Thanks.