### PR TITLE
Clarify version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Redis::Sentinel (Deprecated)
 
-[redis](https://github.com/redis/redis-rb) gem supports sentinel
-from version 3.2, redis-sentinel is not necessary.
+The [redis](https://github.com/redis/redis-rb) gem supports sentinel
+from version 3.2, redis-sentinel is not necessary if you are using Redis 2.8.x or later.
 
 Another redis automatic master/slave failover solution for ruby by
 using built-in redis sentinel.


### PR DESCRIPTION
redis-rb includes sentinel support, but only if you are using Redis 2.8.x.  If you are stuck on an older version if Redis then you need to use  redis-rb 3.1.x and redis-sentinal.

My edit could probably be worded better, but I think something is better than nothing.

Also, referring to the gem as "redis" and the server as "Redis" is a bit confusing, but it seems to be the norm.

Related to https://github.com/flyerhzm/redis-sentinel/issues/55