### PR TITLE
Add a maximum version constraint on `redis`

### DIFF
--- a/redis-sentinel.gemspec
+++ b/redis-sentinel.gemspec
@@ -17,7 +17,13 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "redis"
+  # Sentinel support was added to the `redis` gem in 3.2.0. This gem is purely
+  # incompatible with that version and will behave very improperly by forcing a
+  # connection to Redis on localhost:6379 regardless of the host that Redis
+  # Sentinel gave it. In my tests 3.1.0 works, but you should upgrade to
+  # `redis` 3.2.0+ without `redis-sentinel` instead.
+  gem.add_dependency "redis", '< 3.2.0'
+
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "eventmachine"


### PR DESCRIPTION
If this gem is used in conjunction with `redis` 3.2.0 it won't throw a
runtime error exactly, but the internals have changed enough that it
doesn't do what it's supposed to anymore, and instead of connecting to
the master host suggested by Sentinel, will connect to the `redis`
default host on `localhost:6379`.

This patch puts a maximum version constraint on `redis` of 3.1.0, which
in my tests is still compatible.

This took one of our services down pretty hard, and hopefully this patch
and a new version of `redis-sentinel` will save someone else from the
same fate.